### PR TITLE
2.5.x Workaround for Bug 3129

### DIFF
--- a/plugins/net.bioclipse.scripting.ui/src/net/bioclipse/scripting/ui/views/ScriptingConsoleView.java
+++ b/plugins/net.bioclipse.scripting.ui/src/net/bioclipse/scripting/ui/views/ScriptingConsoleView.java
@@ -401,6 +401,7 @@ public abstract class ScriptingConsoleView extends ViewPart {
         
         synchronized (output) {
             output.append(message);
+            output.setFont(JFaceResources.getTextFont());
             output.redraw();
         }
     }


### PR DESCRIPTION
Arvid did some research and found out the the right font should be already set in the createPartControl method. We don't know yet why it doesn't work, but for now we solve it by setting the font in the printMessage method.
