### PR TITLE
Made the failed-login-dialog use the account name 

### DIFF
--- a/plugins/net.bioclipse.usermanager/src/net/bioclipse/usermanager/business/UserManager.java
+++ b/plugins/net.bioclipse.usermanager/src/net/bioclipse/usermanager/business/UserManager.java
@@ -210,11 +210,10 @@ public class UserManager implements IUserManager {
         try {
             for( IUserManagerListener listener : listeners) {
                 failedLogin.clear();
-                name = listener.getClass().getName();
-                name = name.substring( 0, name.lastIndexOf( '.' ) );
                 ArrayList<String> userAccountTypes = userContainer.getLoggedInUser().getAccountTypes();
                 
                 if (userAccountTypes.contains( listener.getAccountType() )) {
+                    name = listener.getAccountType();
                     loginOK = listener.receiveUserManagerEvent( UserManagerEvent.LOGIN );
                     if (!loginOK) {                    
                         failedLogin.add( name );


### PR DESCRIPTION
I noticed that the dilog that tells if a pluggin fails to login reports the last part of the path to the listener. This commit will make it report the name of the account that the listener belong to. I think that this will make it easier for a user to understand the message.
