### PR TITLE
Fixes truble with the next-button

### DIFF
--- a/plugins/net.bioclipse.usermanager/src/net/bioclipse/usermanager/LoginWizardPage.java
+++ b/plugins/net.bioclipse.usermanager/src/net/bioclipse/usermanager/LoginWizardPage.java
@@ -42,12 +42,19 @@ public class LoginWizardPage extends WizardPage {
 	public void createControl(Composite parent) {
 		Composite container = loginDialogArea.getLoginArea(parent);
 		setControl(container);
-		setPageComplete( isPageComplete() );
+		setPageComplete( false );
 	}
 
 	@Override
+    public boolean canFlipToNextPage() {
+        return loginDialogArea.isFilledIn();
+    }
+	
+	@Override
 	public boolean isPageComplete() {
-		return !loginDialogArea.getErrorFlag();
+	    boolean pageReady = loginDialogArea.isFilledIn();
+	    setPageComplete( pageReady );
+	    return pageReady;
 	}
 	
 	/**


### PR DESCRIPTION
It was discovered that the next button on the login page of the create-new account-wizard was enable even if nether the username nor the password where filled in. This pull request make the next button to be enable only if both those text fields are filled in.
