### PR TITLE
Feature/download specific pd bentry

### DIFF
--- a/plugins/net.bioclipse.webservices/META-INF/MANIFEST.MF
+++ b/plugins/net.bioclipse.webservices/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.eclipse.ui,
  org.springframework.osgi.aopalliance.osgi,
  org.apache.axis;bundle-version="1.4.0",
  javax.xml.soap;bundle-version="1.3.0",
- javax.xml.rpc;bundle-version="1.1.0"
+ javax.xml.rpc;bundle-version="1.1.0",
+ net.bioclipse.business
 Bundle-ClassPath: jars/axis-1_4/lib/axis.jar,
  jars/axis-1_4/lib/jaxrpc.jar,
  jars/axis-1_4/lib/saaj.jar,

--- a/plugins/net.bioclipse.webservices/src/net/bioclipse/webservices/business/IWebservicesManager.java
+++ b/plugins/net.bioclipse.webservices/src/net/bioclipse/webservices/business/IWebservicesManager.java
@@ -10,17 +10,16 @@
  ******************************************************************************/
 package net.bioclipse.webservices.business;
 
-import java.io.IOException;
 import java.util.List;
-
-import org.eclipse.core.resources.IContainer;
-import org.eclipse.core.runtime.CoreException;
 
 import net.bioclipse.core.PublishedClass;
 import net.bioclipse.core.PublishedMethod;
 import net.bioclipse.core.Recorded;
 import net.bioclipse.core.business.BioclipseException;
 import net.bioclipse.managers.business.IBioclipseManager;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.runtime.CoreException;
 
 @PublishedClass(
     value="Contains webservices related methods"
@@ -84,6 +83,13 @@ public interface IWebservicesManager extends IBioclipseManager {
       public String downloadDbEntry(String db, String query, String format)
                     throws BioclipseException, CoreException;
       
+      @Recorded
+      @PublishedMethod(
+          params = "String pdbid",
+          methodSummary = "Download a PDB file from pdb.org." )
+      public String downloadPDBEntry(String pdbid)
+                          throws BioclipseException;
+
       /**
        * 
        * @param pdbids A comma-separated list of PDB IDs to download

--- a/plugins/net.bioclipse.webservices/src/net/bioclipse/webservices/business/WebservicesManager.java
+++ b/plugins/net.bioclipse.webservices/src/net/bioclipse/webservices/business/WebservicesManager.java
@@ -11,13 +11,13 @@
 package net.bioclipse.webservices.business;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.bioclipse.business.BioclipsePlatformManager;
 import net.bioclipse.core.business.BioclipseException;
 import net.bioclipse.managers.business.IBioclipseManager;
 import net.bioclipse.webservices.ResourceCreator;
@@ -29,6 +29,7 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.core.runtime.Path;
 
@@ -146,6 +147,12 @@ public class WebservicesManager implements IBioclipseManager {
         return downloadDbEntryAsFile(db, query, format, "");
     }
 
+    public String downloadPDBEntry(String pdbid,
+            IProgressMonitor monitor)
+            throws BioclipseException {
+    	BioclipsePlatformManager bioclipse = new BioclipsePlatformManager();
+    	return bioclipse.download("http://pdb.org/" + pdbid + ".pdb", monitor);
+    }
     
     /**
      * Download a list of PDBs by ID to a specified location


### PR DESCRIPTION
Currently, the manager has a method to download PDB entries based on a query, but not a method to download one specific PDB entry based on its identifier. This patch adds that functionality.
