### PR TITLE
Changes the description in the EBIWSDbfetchWizardPage

### DIFF
--- a/plugins/net.bioclipse.webservices/src/net/bioclipse/webservices/wizards/wizardpages/EBIWSDbfetchWizardPage.java
+++ b/plugins/net.bioclipse.webservices/src/net/bioclipse/webservices/wizards/wizardpages/EBIWSDbfetchWizardPage.java
@@ -52,7 +52,7 @@ public class EBIWSDbfetchWizardPage extends WizardPage implements IDoPerformFini
 	private static String defPageTitle =
 			"WSDbfetch offers access various up-to-date biological databases.";
 	private static String defPageDescription =
-			"Please select database, format and style and enter the query (in example 1JR8 for pdb, NM_210721 for refseq).";
+			"Please select database, format and style and enter the query (in example 1JR8 for pdb, NM_210721 for refseqn).";
 	private String selDatabase, selFormat, selStyle, selQuery;
 	private boolean blockcombo;
 


### PR DESCRIPTION
The database called refseq used in the description has been split up into two databases. The molecule in the example in the the one called refseqn. This commit make the description refer to the new database. 
