### PR TITLE
5 dev gist update

### DIFF
--- a/plugins/net.bioclipse.gist/src/net/bioclipse/gist/business/GistManager.java
+++ b/plugins/net.bioclipse.gist/src/net/bioclipse/gist/business/GistManager.java
@@ -58,6 +58,11 @@ public class GistManager implements IBioclipseManager {
 
     public void download(int gist, IReturner<IFile> returner, IProgressMonitor monitor)
                   throws BioclipseException {
+    	download(Integer.toString(gist), returner, monitor);
+    }
+
+    public void download(String gist, IReturner<IFile> returner, IProgressMonitor monitor)
+                  throws BioclipseException {
 
         if (monitor == null) {
             monitor = new NullProgressMonitor();

--- a/plugins/net.bioclipse.gist/src/net/bioclipse/gist/business/IGistManager.java
+++ b/plugins/net.bioclipse.gist/src/net/bioclipse/gist/business/IGistManager.java
@@ -41,4 +41,13 @@ public interface IGistManager extends IBioclipseManager {
     )
     public List<IFile> download(int gist);
     public BioclipseJob<IFile> download( int gist, BioclipseJobUpdateHook<List<IFile>> hook );
+
+    @Recorded
+    @PublishedMethod(
+        params = "String gist",
+        methodSummary = "Downloads the Gist with the given identifier to the " +
+                        "project 'Gists/' and returns the path"
+    )
+    public List<IFile> download(String gist);
+    public BioclipseJob<IFile> download( String gist, BioclipseJobUpdateHook<List<IFile>> hook );
 }


### PR DESCRIPTION
Arvid, GitHub changed the Gist API a bit, again, and now have identifiers using hexadecimal, so I added an alternative download method that takes a String.

And it works properly on my machine:

> gist.download("84730fdd508128cea544")
> List<File> of size 5
