### PR TITLE
Catch any Throwable, as getErrorMessage can handle anyway

### DIFF
--- a/plugins/net.bioclipse.scripting.ui/src/net/bioclipse/scripting/ui/views/GroovyConsoleView.java
+++ b/plugins/net.bioclipse.scripting.ui/src/net/bioclipse/scripting/ui/views/GroovyConsoleView.java
@@ -130,9 +130,9 @@ public class GroovyConsoleView extends ScriptingConsoleView {
                      public void run() {
                          if ( null != result ) {
                              if (result instanceof Object) {
-                                 if (result instanceof Exception) {
+                                 if (result instanceof Throwable) {
                                      message[0]
-                                         = getErrorMessage((Exception)result);
+                                         = getErrorMessage((Throwable)result);
                                  }
                                  else if (result instanceof List<?>) {
                                      List<?> list = (List<?>)result;


### PR DESCRIPTION
Arvid, previously only Exception's were catched, but the bioclipse.core's StringMatrix is throwing Errors (independent whether that is proper code...), but the method that handles the exception can just as well handle any Throwable, so I changed the catch part.

This should fix an issue my PhD student (Bart) was having where doing

stringMatrix.getColumn("Doesn't exist")

caused the full GroovyConsole to crash.
