### PR TITLE
Report the BioclipseException message if found in the stack

### DIFF
--- a/plugins/net.bioclipse.scripting/src/net/bioclipse/scripting/GroovyEnvironment.java
+++ b/plugins/net.bioclipse.scripting/src/net/bioclipse/scripting/GroovyEnvironment.java
@@ -127,6 +127,9 @@ public class GroovyEnvironment implements ScriptingEnvironment {
         try {
             Object o = engine.eval(expression);
             return o;
+        } catch ( IllegalAccessError e ) {
+            // TODO: this can be thrown by the StringMatrix, which should probably be fixed instead
+            return e.getMessage();
         } catch ( ScriptException e ) {
             BioclipseException bioEx = getBioclipseException(e);
             if (bioEx != null) {

--- a/plugins/net.bioclipse.scripting/src/net/bioclipse/scripting/GroovyEnvironment.java
+++ b/plugins/net.bioclipse.scripting/src/net/bioclipse/scripting/GroovyEnvironment.java
@@ -8,6 +8,8 @@
  *******************************************************************************/
 package net.bioclipse.scripting;
 
+import groovy.lang.GroovyRuntimeException;
+
 import java.io.Writer;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -135,6 +137,14 @@ public class GroovyEnvironment implements ScriptingEnvironment {
             if (bioEx != null) {
                 return bioEx.getMessage();
             }
+            CoreException resEx = getEclipseException(e);
+            if (resEx != null) {
+                return resEx.getMessage();
+            }
+            GroovyRuntimeException grEx = getGroovyRuntimeException(e);
+            if (grEx != null) {
+                return grEx.getMessage();
+            }
             String message = e.getMessage();
             if( !message.contains( "Can't find method " ))
             throw new RuntimeException(e);
@@ -147,6 +157,26 @@ public class GroovyEnvironment implements ScriptingEnvironment {
         while (cause != null) {
             if (cause instanceof BioclipseException)
                 return (BioclipseException)cause;
+            cause = cause.getCause();
+        }
+        return null;
+    }
+
+    private CoreException getEclipseException(ScriptException exception) {
+        Throwable cause = exception.getCause();
+        while (cause != null) {
+            if (cause instanceof CoreException)
+                return (CoreException)cause;
+            cause = cause.getCause();
+        }
+        return null;
+    }
+
+    private GroovyRuntimeException getGroovyRuntimeException(ScriptException exception) {
+        Throwable cause = exception.getCause();
+        while (cause != null) {
+            if (cause instanceof GroovyRuntimeException)
+                return (GroovyRuntimeException)cause;
             cause = cause.getCause();
         }
         return null;


### PR DESCRIPTION
This improves the user experience, by reporting the exception message of the top-most BioclipseException, rather than a general message of one of the wrapping Exceptions. If the stack does not contain a BioclipseExclipse, it will default to the original behavior.