### PR TITLE
Fix typo in label generated by DenseDataset

### DIFF
--- a/plugins/net.bioclipse.core/src/net/bioclipse/core/domain/DenseDataset.java
+++ b/plugins/net.bioclipse.core/src/net/bioclipse/core/domain/DenseDataset.java
@@ -100,7 +100,7 @@ public class DenseDataset implements IDataset{
 		if (responseProperty!=null)
 			 rowstring = rowstring + responseProperty;
 
-		buf.append("Molceulce" + separator + rowstring + "\n");
+		buf.append("Molecule" + separator + rowstring + "\n");
 
 		int c=0;
 		for (List<Float> row : values){


### PR DESCRIPTION
The "Molecule" label was erroneously "Molceulce". This commit fixes this.