### PR TITLE
Adds a method to call a remote SPARQL end point, but without having to use Jena.

### DIFF
--- a/features/net.bioclipse.core_feature/feature.xml
+++ b/features/net.bioclipse.core_feature/feature.xml
@@ -75,6 +75,8 @@ The Eclipse Public License accompanies this distribution, and is available at ht
       <import plugin="org.eclipse.equinox.p2.metadata"/>
       <import plugin="org.eclipse.equinox.p2.operations"/>
       <import plugin="org.openscience.cdk_bundle"/>
+      <import plugin="org.apache.httpcomponents.httpclient"/>
+      <import plugin="org.apache.httpcomponents.httpcore"/>
    </requires>
 
    <plugin

--- a/plugins/net.bioclipse.business/META-INF/MANIFEST.MF
+++ b/plugins/net.bioclipse.business/META-INF/MANIFEST.MF
@@ -12,7 +12,9 @@ Require-Bundle: org.eclipse.ui,
  net.bioclipse.core,
  net.bioclipse.ui,
  ch.qos.logback.core;bundle-version="[1.0.0,2.0.0)",
- ch.qos.logback.classic;bundle-version="[1.0.0,2.0.0)"
+ ch.qos.logback.classic;bundle-version="[1.0.0,2.0.0)",
+ org.apache.httpcomponents.httpclient,
+ org.apache.httpcomponents.httpcore
 Bundle-ActivationPolicy: lazy
 Import-Package: org.apache.log4j,
  org.slf4j

--- a/plugins/net.bioclipse.business/src/net/bioclipse/business/IBioclipsePlatformManager.java
+++ b/plugins/net.bioclipse.business/src/net/bioclipse/business/IBioclipsePlatformManager.java
@@ -1,5 +1,4 @@
-/* *****************************************************************************
- * Copyright (c) 2009  Egon Willighagen <egonw@users.sf.net>
+/* Copyright (c) 2009,2018  Egon Willighagen <egonw@users.sf.net>
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -7,7 +6,7 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contact: http://www.bioclipse.net/
- ******************************************************************************/
+ */
 package net.bioclipse.business;
 
 import org.eclipse.core.resources.IFile;
@@ -106,4 +105,11 @@ public interface IBioclipsePlatformManager extends IBioclipseManager {
     public String fullPath( String file );
     
     public String fullPath( IFile file );
+
+    @PublishedMethod(
+        params = "String url, String SPARQL",
+        methodSummary = "Queries a remote SPARQL end point without parsing the SPARQL first."
+    )
+    public byte[] sparqlRemote(String url, String SPARQL)
+        throws BioclipseException;
 }


### PR DESCRIPTION
The reason why this is needed is the Jena tries to parse the SPARQL and complains
about non-standard extensions, e.g. by Blazegraph. Because the returned content is
XML, I opted for returning a byte stream, as passing around Java String sometimes
conflicts with XML content.

This allows a script like:

    rawResults = bioclipse.sparqlRemote(
        "https://query.wikidata.org/sparql", sparql
    )
    results = rdf.processSPARQLXML(rawResults, sparql)

Full example: https://gist.github.com/egonw/ca4c348b9a2d1116efcdb55fa85dd158

This PR is linked to one for bioclipse.rdf, which I'll prepare next.